### PR TITLE
YanghuiTriangle

### DIFF
--- a/YanghuiTriangle.py
+++ b/YanghuiTriangle.py
@@ -16,3 +16,29 @@ def row(n):
         return y
 print(row(10))
 print(yanghui(10))
+
+
+
+def yanghui2(n):
+    if n == 1:
+        return [[1]]
+    if n == 2:
+        return [[1], [1, 1]]
+    if n>2:
+        y = [1]*n
+        for i in range(1, n-1):
+            y[i]=yanghui2(n-1)[-1][i-1]+yanghui2(n-1)[-1][i]
+        print(y)
+        return yanghui2(n-1).append(y)
+    
+    
+
+def yanghui3(n):
+    yanghui=[[1]*(i+1) for i in range(n)]
+    for i in range(2,n):
+        for j in range(1,i):
+            yanghui[i][j]=yanghui[i-1][j-1]+yanghui[i-1][j]
+    return yanghui
+
+print(yanghui3(10))
+

--- a/YanghuiTriangle.py
+++ b/YanghuiTriangle.py
@@ -1,0 +1,18 @@
+def yanghui(n):
+    res=[]
+    for i in range(1,n+1):
+        res.append(row(i))
+    return res
+
+def row(n):
+    if n==1:
+        return [1]
+    if n==2:
+        return [1,1]
+    if n>2:
+        y=[1]*n
+        for i in range(1,n-1):
+            y[i]=row(n-1)[i-1]+row(n-1)[i]
+        return y
+print(row(10))
+print(yanghui(10))


### PR DESCRIPTION
笨办法算杨辉三角，能通过测试，效率貌似是O(n**3)，算到100行就明显很慢了。
尝试用下面方法，少一层迭代，效率提高至O(n**2)，但是通不过。

```python
def yanghui2(n):
    if n == 1:
        return [[1]]
    if n == 2:
        return [[1], [1, 1]]
    if n>2:
        y = [1]*n
        for i in range(1, n-1):
            y[i]=yanghui2(n-1)[-1][i-1]+yanghui2(n-1)[-1][i]
        tempt=yanghui2(n-1)
        tempt.append(y)
        return tempt

```

**problem here** `yanghui2(n-1).append(y)` returns `None`, it only append element y to the list, another important point is, you 'd better to save yanghui2(n-1) in a variable to avoid unnecessary computation. 